### PR TITLE
changed FULLSCREEN flags for new kindle fire 2015

### DIFF
--- a/src/android/NavigationBar.java
+++ b/src/android/NavigationBar.java
@@ -106,7 +106,8 @@ public class NavigationBar extends CordovaPlugin {
 			activity.getWindow().getDecorView().setSystemUiVisibility(
 				View.SYSTEM_UI_FLAG_HIDE_NAVIGATION//
 				| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-				//| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+				| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+				| View.SYSTEM_UI_FLAG_FULLSCREEN
 				//| View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 				| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
 			);							
@@ -129,7 +130,8 @@ public class NavigationBar extends CordovaPlugin {
 								activity.getWindow().getDecorView().setSystemUiVisibility(
 									View.SYSTEM_UI_FLAG_HIDE_NAVIGATION//
 									| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-									//| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+									| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+									| View.SYSTEM_UI_FLAG_FULLSCREEN
 									//| View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 									| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
 								);							
@@ -165,7 +167,8 @@ public class NavigationBar extends CordovaPlugin {
 		activity.getWindow().getDecorView().setSystemUiVisibility(
 			View.SYSTEM_UI_FLAG_HIDE_NAVIGATION//
 			| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-			//| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+			| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+			| View.SYSTEM_UI_FLAG_FULLSCREEN
 			//| View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 			| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
 		);	


### PR DESCRIPTION
transparent navigation bar and statusbar did disappear on kindle fire 2015. re-adding View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN and additional View.SYSTEM_UI_FLAG_FULLSCREEN seems to solve the problem
